### PR TITLE
Add tests for data sources, skills generation, and link audit

### DIFF
--- a/src/tests/test_data_sources.py
+++ b/src/tests/test_data_sources.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from github_is_my_cms.data_sources import (
+    GitHubFetcher,
+    PyPIDiscoveryFetcher,
+    PyPIStatsFetcher,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload: Dict[str, Any], status: int = 200):
+        self._payload = payload
+        self.status = status
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+def test_github_fetcher_uses_cache(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "cache"
+    fetcher = GitHubFetcher(cache_dir)
+    payload = [{"name": "repo-one"}]
+
+    fetcher.cache_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert fetcher.fetch_repos() == payload
+
+
+def test_pypi_discovery_fetcher_uses_cache(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "cache"
+    fetcher = PyPIDiscoveryFetcher(cache_dir)
+    payload = {"user": "tester", "packages": ["alpha", "bravo"]}
+
+    fetcher.cache_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert fetcher.fetch_user_packages("tester") == ["alpha", "bravo"]
+
+
+def test_pypi_stats_fetcher_parses_keywords_and_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fetcher = PyPIStatsFetcher()
+    payload = {
+        "info": {
+            "version": "1.2.3",
+            "summary": "Demo package",
+            "home_page": "https://example.com",
+            "project_urls": {"Source": "https://github.com/example/demo"},
+            "keywords": "tag1, tag2",
+        }
+    }
+
+    def fake_urlopen(request: Any) -> FakeResponse:
+        return FakeResponse(payload)
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    details = fetcher.fetch_details("demo")
+
+    assert details["github_repo"] == "example/demo"
+    assert details["tags"] == ["tag1", "tag2"]

--- a/src/tests/test_generate_skills_and_audit_links.py
+++ b/src/tests/test_generate_skills_and_audit_links.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+import tomllib
+from _pytest.capture import CaptureFixture
+
+from github_is_my_cms.audit_links import run_audit
+from github_is_my_cms.generate_skills import run_generation
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.write_text(dedent(content), encoding="utf-8")
+
+
+def _write_shared_fixture(root: Path) -> None:
+    data_dir = root / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    templates_dir = root / "src" / "github_is_my_cms" / "templates" / "default"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_text(
+        root / "readme_cms.toml",
+        """
+        [mode]
+        current = "project_promotion"
+
+        [languages]
+        default = "en"
+        supported = ["en"]
+        """,
+    )
+
+    _write_text(
+        data_dir / "identity.toml",
+        """
+        name = "Example Person"
+        tagline = "Example Tagline"
+        """,
+    )
+
+    _write_text(
+        data_dir / "skills.toml",
+        """
+        [[skills]]
+        category = "Languages"
+        [[skills.skills]]
+        name = "Python"
+        aliases = ["py"]
+        featured = true
+        """,
+    )
+
+    _write_text(
+        data_dir / "projects.toml",
+        """
+        [[projects]]
+        slug = "project-one"
+        name = "Project One"
+        description = "Example project"
+        tags = ["py", "lonely-tag"]
+        primary_language = "Go"
+        """,
+    )
+
+    _write_text(
+        data_dir / "pypi_projects.toml",
+        """
+        [[packages]]
+        package_name = "example-pkg"
+        summary = "Example package"
+        tags = ["docs"]
+        """,
+    )
+
+    _write_text(
+        data_dir / "work_experience.toml",
+        """
+        [[experience]]
+        id = "exp-1"
+        organization = "Example Org"
+        title = "Example Role"
+        employment_type = "full_time"
+        start_date = "2020-01"
+        end_date = "2021-01"
+        technologies = ["GraphQL"]
+        """,
+    )
+
+    _write_text(
+        data_dir / "resumes.toml",
+        """
+        resumes = []
+        """,
+    )
+
+
+def test_run_generation_writes_new_skill_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_shared_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    run_generation()
+
+    output_path = tmp_path / "data" / "skills.new.toml"
+    assert output_path.exists()
+
+    contents = tomllib.loads(output_path.read_text(encoding="utf-8"))
+    categories = {item["category"] for item in contents["skills"]}
+
+    assert "Inbox - From Resume" in categories
+    assert "Inbox - From GitHub" in categories
+
+
+def test_run_audit_reports_orphans(
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_shared_fixture(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    run_audit()
+
+    captured = capsys.readouterr().out
+    assert "Orphan Tags" in captured
+    assert "Ghost Skills" in captured
+    assert "Unlinked Resume Technologies" in captured


### PR DESCRIPTION
### Motivation
- Increase test coverage for data fetchers and the skills generation / audit code paths that previously had little or no coverage.
- Validate cache behavior for fetchers and ensure PyPI metadata parsing (keywords and GitHub repo extraction) works as expected.
- Provide lightweight integration tests that exercise `generate_skills` and `audit_links` using filesystem fixtures instead of heavy mocking.
- Follow project testing guidance by using `tmp_path` and minimal monkeypatching.

### Description
- Added `src/tests/test_data_sources.py` with unit tests for `GitHubFetcher`, `PyPIDiscoveryFetcher`, and `PyPIStatsFetcher` including a small `FakeResponse` and a `monkeypatch` of `urllib.request.urlopen` to validate parsing logic.
- Added `src/tests/test_generate_skills_and_audit_links.py` with integration-style tests that write TOML fixtures to `tmp_path` and run `run_generation()` and `run_audit()` to validate output and console reports.
- Tests rely on `tmp_path`, `monkeypatch`, and `capsys` to avoid global state changes and to capture output.
- New tests exercise cache-read paths and ensure the generated `data/skills.new.toml` contains expected categories and that the audit prints the expected sections.

### Testing
- Ran `uv run pytest src/tests/test_data_sources.py src/tests/test_generate_skills_and_audit_links.py` as the test command.
- All tests passed: `5 passed`.
- Tests use `tmp_path` fixtures and minimal `monkeypatch` to avoid external network or CLI dependencies.
- No automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69504c16a890832792582f6ba1b0443a)